### PR TITLE
fix issues with dockerfile building

### DIFF
--- a/local-publish.sh
+++ b/local-publish.sh
@@ -5,7 +5,7 @@ set -e
 eval SOURCE="~/.nuget/packages"
 
 CONFIGURATION="Release"
-VERSION="1.4.0-SNAPSHOT"
+VERSION="1.4.2-SNAPSHOT"
 
 function local_publish() {
     dotnet pack $1 -c ${CONFIGURATION} -property:Version=${VERSION}

--- a/src/Container.Abstractions/Container.Abstractions.csproj
+++ b/src/Container.Abstractions/Container.Abstractions.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>TestContainers.Container.Abstractions</AssemblyName>
     <Description>DotNet port of testcontainers.org</Description>
 
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Authors>Isen Ng</Authors>
 
     <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>

--- a/src/Container.Abstractions/Images/DockerfileImage.cs
+++ b/src/Container.Abstractions/Images/DockerfileImage.cs
@@ -171,16 +171,22 @@ namespace TestContainers.Container.Abstractions.Images
                 ? File.ReadLines(dockerIgnorePath)
                     .Where(line => !string.IsNullOrWhiteSpace(line))
                     .Select(line => line.Trim())
+                    .Where(line => !line.StartsWith("#"))
                     .ToList()
                 : new List<string>();
         }
 
         private static bool IsFileIgnored(IEnumerable<string> ignores, string relativePath)
         {
-            var matches = ignores
-                .Select(i => i.StartsWith("!") ? i.Substring(1) : i)
-                .Where(i => GoLangFileMatch.Match(i, relativePath))
-                .ToList();
+            var matches = new List<string>();
+            foreach (var ignore in ignores)
+            {
+                var goLangPattern = ignore.StartsWith("!") ? ignore.Substring(1) : ignore;
+                if (GoLangFileMatch.Match(goLangPattern, relativePath))
+                {
+                    matches.Add(ignore);
+                }
+            }
 
             if (matches.Count <= 0)
             {

--- a/src/Container.Abstractions/Utilities/GoLang/GoLangFileMatch.cs
+++ b/src/Container.Abstractions/Utilities/GoLang/GoLangFileMatch.cs
@@ -17,7 +17,7 @@ namespace TestContainers.Container.Abstractions.Utilities.GoLang
         internal static readonly bool IsWindows = Path.DirectorySeparatorChar == '\\';
         private const string PatternCharsToEscape = "\\.[]{}()*+-?^$|";
 
-        private static readonly Dictionary<string, string> PatternCache = new Dictionary<string, string>();
+        private static readonly Dictionary<string, Regex> RegexCache = new Dictionary<string, Regex>();
 
         /// <summary>
         /// Returns the matching patterns for the given string
@@ -38,23 +38,29 @@ namespace TestContainers.Container.Abstractions.Utilities.GoLang
         /// <returns>whether the pattern matches the input</returns>
         public static bool Match(string pattern, string name)
         {
-            // use `Regex.IsMatch` instead of returning a `new Regex` because according to the source code
-            // only these static method caches the compiled pattern, while `new Regex` ignores the compiled option
-            return Regex.IsMatch(name, BuildPattern(pattern), RegexOptions.Compiled, Regex.InfiniteMatchTimeout);
-        }
-
-        private static string BuildPattern(string pattern)
-        {
             if (pattern == null)
             {
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            if (PatternCache.TryGetValue(pattern, out var goLangPattern))
+            if (name == null)
             {
-                return goLangPattern;
+                throw new ArgumentNullException(nameof(name));
             }
 
+            if (RegexCache.TryGetValue(pattern, out var regex))
+            {
+                return regex.IsMatch(name);
+            }
+
+            regex = new Regex(BuildPattern(pattern), RegexOptions.Compiled);
+            RegexCache[pattern] = regex;
+
+            return regex.IsMatch(name);
+        }
+
+        private static string BuildPattern(string pattern)
+        {
             var patternStringBuilder = new StringBuilder("^");
             while (!string.IsNullOrWhiteSpace(pattern))
             {
@@ -67,10 +73,7 @@ namespace TestContainers.Container.Abstractions.Utilities.GoLang
             }
 
             patternStringBuilder.Append("(").Append(Quote(Path.DirectorySeparatorChar)).Append(".*").Append(")?$");
-            goLangPattern = patternStringBuilder.ToString();
-            PatternCache[pattern] = goLangPattern;
-
-            return goLangPattern;
+            return patternStringBuilder.ToString();
         }
 
         private static string Quote(char separatorChar)

--- a/src/Container.Database.AdoNet/Container.Database.AdoNet.csproj
+++ b/src/Container.Database.AdoNet/Container.Database.AdoNet.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>TestContainers.Container.Database.AdoNet</AssemblyName>
     <Description>DotNet port of testcontainers.org</Description>
 
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Authors>Isen Ng</Authors>
 
     <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>

--- a/src/Container.Database.ArangoDb/Container.Database.ArangoDb.csproj
+++ b/src/Container.Database.ArangoDb/Container.Database.ArangoDb.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>TestContainers.Container.Database.ArangoDb</AssemblyName>
     <Description>DotNet port of testcontainers.org</Description>
 
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Authors>Isen Ng</Authors>
 
     <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>

--- a/src/Container.Database.MsSql/Container.Database.MsSql.csproj
+++ b/src/Container.Database.MsSql/Container.Database.MsSql.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>TestContainers.Container.Database.MsSql</AssemblyName>
     <Description>DotNet port of testcontainers.org</Description>
 
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Authors>Isen Ng</Authors>
 
     <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>

--- a/src/Container.Database.PostgreSql/Container.Database.PostgreSql.csproj
+++ b/src/Container.Database.PostgreSql/Container.Database.PostgreSql.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>TestContainers.Container.Database.PostgreSql</AssemblyName>
     <Description>DotNet port of testcontainers.org</Description>
 
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Authors>Isen Ng</Authors>
 
     <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>

--- a/src/Container.Database/Container.Database.csproj
+++ b/src/Container.Database/Container.Database.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>TestContainers.Container.Database</AssemblyName>
     <Description>DotNet port of testcontainers.org</Description>
 
-    <Version>1.4.1</Version>
+    <Version>1.4.2</Version>
     <Authors>Isen Ng</Authors>
 
     <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>


### PR DESCRIPTION
1. Fixed parsing dockerignore file: now properly ignores comments in the file
2. Fixed an issue where building the docker image dramatically slows down when there are more than 15 entries in .dockerignore