### PR TITLE
Fix issue caused by MySqlConnector namespace change

### DIFF
--- a/src/Container.Database.MySql/ClientFactoryAccessor.cs
+++ b/src/Container.Database.MySql/ClientFactoryAccessor.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Data.Common;
+using System.Linq;
+using System.Reflection;
+
+namespace TestContainers.Container.Database.MySql
+{
+    /// <summary>
+    /// This class is used to give access to a compatible DbProviderFactory for MySql
+    /// based on the available types at runtime.
+    /// </summary>
+    /// <remarks>
+    /// It is needed because multiple provider exist and because MySqlConnector had a breaking change in v1.0
+    /// so the namespace and class name of the provider may change based on the referenced packages.
+    /// </remarks>
+    internal static class ClientFactoryAccessor
+    {
+        private static readonly (string assemblyName, string typeName)[] ProviderFactoryTypes = {
+            ("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory"),
+            ("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory"),
+            ("MySqlConnector", "MySqlConnector.MySqlConnectorFactory"),
+        };
+
+        /// <summary>
+        /// Provides an instance of <see cref="DbProviderFactory"/> for MySql, based on the available types
+        /// </summary>
+        public static readonly DbProviderFactory ClientFactoryInstance = GetFactoryInstance();
+
+        private static DbProviderFactory GetFactoryInstance()
+        {
+            //Try to find a valid `Instance` property for each know provider type
+            foreach ((string assemblyName, string typeName) in ProviderFactoryTypes)
+            {
+                try
+                {
+                    var assembly = Assembly.Load(new AssemblyName(assemblyName));
+                    var providerFactoryType = assembly.GetType(typeName);
+                    var instanceProperty = providerFactoryType.GetFields().FirstOrDefault(p =>
+                        string.Equals(p.Name, "Instance", StringComparison.OrdinalIgnoreCase) && p.IsStatic);
+                    if (instanceProperty is null)
+                    {
+                        continue;
+                    }
+                    return (DbProviderFactory)instanceProperty.GetValue(null);
+                }
+                catch (Exception)
+                {
+                    // Could not load this factory, try with next one
+                }
+            }
+            throw new TypeLoadException("Could not load any DbProviderFactory type. " +
+                                        "Ensure that a suitable MySQL data provider is installed."
+            );
+        }
+    }
+}

--- a/src/Container.Database.MySql/MySqlContainer.cs
+++ b/src/Container.Database.MySql/MySqlContainer.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Data.Common;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Docker.DotNet;
 using Microsoft.Extensions.DependencyInjection;
@@ -40,46 +38,8 @@ namespace TestContainers.Container.Database.MySql
 
         private string _connectionString;
 
-        /*
-         * NOTE: MySqlConnector made a breaking change in v1.0 by changing the namespace.
-         * We have to try loading multiple types of DbProviderFactory depending on the installed version.
-         * Once found, the DbProviderFactory is cached in this Lazy instance.
-         */
-        private static readonly Lazy<DbProviderFactory> s_lazyDbProviderFactory = new Lazy<DbProviderFactory>(() =>
-        {
-            var providerFactoryTypes = new[]
-            {
-                ("MySql.Data", "MySql.Data.MySqlClient.MySqlClientFactory"),
-                ("MySqlConnector", "MySql.Data.MySqlClient.MySqlClientFactory"),
-                ("MySqlConnector", "MySqlConnector.MySqlConnectorFactory"),
-            };
-            foreach ((string assemblyName, string typeName) in providerFactoryTypes)
-            {
-                try
-                {
-                    var asmName = new AssemblyName(assemblyName);
-                    var asm = Assembly.Load(asmName);
-                    var providerFactoryType = asm.GetType(typeName);
-                    var prop = providerFactoryType.GetFields().FirstOrDefault(p =>
-                        string.Equals(p.Name, "Instance", StringComparison.OrdinalIgnoreCase) && p.IsStatic);
-                    if (prop is null)
-                    {
-                        continue;
-                    }
-                    return (DbProviderFactory)prop.GetValue(null);
-                }
-                catch (Exception)
-                {
-                    // Could not load this factory, try with next one
-                }
-            }
-            throw new TypeLoadException("Could not load any DbProviderFactory type. " +
-                                        "Ensure that a suitable MySQL data provider is installed."
-            );
-        });
-
         /// <inheritdoc />
-        protected override DbProviderFactory DbProviderFactory => s_lazyDbProviderFactory.Value;
+        protected override DbProviderFactory DbProviderFactory { get; } = ClientFactoryAccessor.ClientFactoryInstance;
 
         /// <inheritdoc />
         public MySqlContainer(IDockerClient dockerClient, ILoggerFactory loggerFactory)


### PR DESCRIPTION
There was a breaking change in MySqlConnector v1.0. See https://github.com/mysql-net/MySqlConnector/releases/tag/1.0.0

Because of that, the test container throws an exception if MySqlConnector >= 1.0

We have to load the `DbProviderFactory` dynamically to make it compatible with both versions.