### PR TITLE
Improve reaper handling and general probing

### DIFF
--- a/src/Container.Abstractions/AbstractContainer.cs
+++ b/src/Container.Abstractions/AbstractContainer.cs
@@ -13,7 +13,6 @@ using TestContainers.Container.Abstractions.Images;
 using TestContainers.Container.Abstractions.Models;
 using TestContainers.Container.Abstractions.Networks;
 using TestContainers.Container.Abstractions.StartupStrategies;
-using TestContainers.Container.Abstractions.Utilities;
 using TestContainers.Container.Abstractions.WaitStrategies;
 
 namespace TestContainers.Container.Abstractions
@@ -93,6 +92,9 @@ namespace TestContainers.Container.Abstractions
 
         /// <inheritdoc />
         public string WorkingDirectory { get; set; }
+
+        /// <inheritdoc />
+        public List<string> Entrypoint { get; set; }
 
         /// <inheritdoc />
         public List<string> Command { get; set; } = new List<string>();
@@ -382,6 +384,7 @@ namespace TestContainers.Container.Abstractions
                     e => default(EmptyStruct)),
                 Labels = Labels,
                 WorkingDir = WorkingDirectory,
+                Entrypoint = Entrypoint,
                 Cmd = Command,
                 Tty = true,
                 AttachStderr = true,
@@ -403,10 +406,7 @@ namespace TestContainers.Container.Abstractions
                     }),
                 Mounts = BindMounts.Select(m => new Mount
                     {
-                        Source = m.HostPath,
-                        Target = m.ContainerPath,
-                        ReadOnly = m.AccessMode == AccessMode.ReadOnly,
-                        Type = "bind"
+                        Source = m.HostPath, Target = m.ContainerPath, ReadOnly = m.AccessMode == AccessMode.ReadOnly, Type = "bind"
                     })
                     .ToList(),
                 PublishAllPorts = true,
@@ -429,8 +429,7 @@ namespace TestContainers.Container.Abstractions
 
             return new CreateContainerParameters(config)
             {
-                HostConfig = hostConfig,
-                NetworkingConfig = networkConfig
+                HostConfig = hostConfig, NetworkingConfig = networkConfig
             };
         }
 

--- a/src/Container.Abstractions/Container.Abstractions.csproj
+++ b/src/Container.Abstractions/Container.Abstractions.csproj
@@ -6,6 +6,7 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Container.Abstractions/IContainer.cs
+++ b/src/Container.Abstractions/IContainer.cs
@@ -86,6 +86,11 @@ namespace TestContainers.Container.Abstractions
         string WorkingDirectory { get; set; }
 
         /// <summary>
+        /// Entrypoint to set when the container starts
+        /// </summary>
+        List<string> Entrypoint { get; set; }
+
+        /// <summary>
         /// Command to run when the container starts
         /// </summary>
         List<string> Command { get; set; }

--- a/src/Container.Abstractions/Images/GenericImage.cs
+++ b/src/Container.Abstractions/Images/GenericImage.cs
@@ -79,9 +79,10 @@ namespace TestContainers.Container.Abstractions.Images
         private async Task PullImage(CancellationToken ct)
         {
             _logger.LogInformation("Pulling container image: {}", ImageName);
+            var tagSplitIdx = ImageName.LastIndexOf(":", StringComparison.InvariantCultureIgnoreCase);
             var createParameters = new ImagesCreateParameters
             {
-                FromImage = ImageName, Tag = ImageName.Split(':').Last(),
+                FromImage = ImageName.Substring(0, tagSplitIdx), Tag = ImageName.Substring(tagSplitIdx+1),
             };
 
             await DockerClient.Images.CreateImageAsync(

--- a/src/Container.Abstractions/WaitStrategies/AbstractProbingStrategy.cs
+++ b/src/Container.Abstractions/WaitStrategies/AbstractProbingStrategy.cs
@@ -37,7 +37,15 @@ namespace TestContainers.Container.Abstractions.WaitStrategies
         public async Task WaitUntil(IContainer container)
         {
             var exceptionPolicy = Policy
-                .Handle<Exception>(e => ExceptionTypes.Any(t => t.IsInstanceOfType(e)))
+                .Handle<Exception>(e =>
+                {
+                    if (e is AggregateException ae)
+                    {
+                        return ae.InnerExceptions.Any(ie => ExceptionTypes.Any(t => t.IsInstanceOfType(ie)));
+                    }
+
+                    return ExceptionTypes.Any(t => t.IsInstanceOfType(e));
+                })
                 .WaitAndRetryForeverAsync(_ => RetryInterval);
 
             var result = await Policy

--- a/src/Container.Database.MySql/MySqlContainer.cs
+++ b/src/Container.Database.MySql/MySqlContainer.cs
@@ -18,7 +18,7 @@ namespace TestContainers.Container.Database.MySql
         /// <summary>
         /// Default image name
         /// </summary>
-        public new const string DefaultImage = "mysql";
+        public new const string DefaultImage = "docker.io/mysql";
 
         /// <summary>
         /// Default image tag

--- a/test/Container.Database.MySql.Integration.Tests/Container.Database.MySql.Integration.Tests.csproj
+++ b/test/Container.Database.MySql.Integration.Tests/Container.Database.MySql.Integration.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <IsPackable>false</IsPackable>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR covers a few things, which is why I'm not sure if I should split it into multiple but I thought I'd let the maintainer(s) decide if this is preferred.

Most important parts are:

* unwrap `AggregateException` in exception policy
* avoid passing the image twice to the Docker API (this is one part required allowing to use Podman because Podman otherwise complains about malformed image spec)
* Support common testcontainers environment variables in ryuk/reaper to override the Docker socket path, this is the second part required to support Podman/Docker rootless