### PR TITLE
Simplify projects

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.2.x
+        uses: actions/setup-dotnet@v3
 
       - name: Install sonar tool
         run: dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.2.x
+        uses: actions/setup-dotnet@v3
 
       - name: Install sonar tool
         run: dotnet tool install --global dotnet-sonarscanner

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -12,9 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.2.x
+        uses: actions/setup-dotnet@v3
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,9 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 2.2.x
+        uses: actions/setup-dotnet@v3
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.400",
+    "allowPrerelease": false,
+    "rollForward": "latestMinor"
+  }
+}

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "version": "6.0.400",
     "allowPrerelease": false,
-    "rollForward": "latestMinor"
+    "rollForward": "latestFeature"
   }
 }

--- a/src/Container.Abstractions/Container.Abstractions.csproj
+++ b/src/Container.Abstractions/Container.Abstractions.csproj
@@ -1,28 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TestContainers.Container.Abstractions</RootNamespace>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>TestContainers.Container.Abstractions</AssemblyName>
-    <Description>DotNet port of testcontainers.org</Description>
-
-    <Version>1.5.4</Version>
-    <Authors>Isen Ng</Authors>
-
-    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
-
-    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <PackageTags>testcontainers docker test tests testing nunit xunit integration</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Container.Database.AdoNet/Container.Database.AdoNet.csproj
+++ b/src/Container.Database.AdoNet/Container.Database.AdoNet.csproj
@@ -3,25 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TestContainers.Container.Database.AdoNet</RootNamespace>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>TestContainers.Container.Database.AdoNet</AssemblyName>
-    <Description>DotNet port of testcontainers.org</Description>
-
-    <Version>1.5.4</Version>
-    <Authors>Isen Ng</Authors>
-
-    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
-
-    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <PackageTags>testcontainers docker test tests testing nunit xunit integration database adonet</PackageTags>
+    <PackageTags>$(PackageTags) database adonet</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Container.Database.ArangoDb/Container.Database.ArangoDb.csproj
+++ b/src/Container.Database.ArangoDb/Container.Database.ArangoDb.csproj
@@ -3,25 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TestContainers.Container.Database.ArangoDb</RootNamespace>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>TestContainers.Container.Database.ArangoDb</AssemblyName>
-    <Description>DotNet port of testcontainers.org</Description>
-
-    <Version>1.5.4</Version>
-    <Authors>Isen Ng</Authors>
-
-    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
-
-    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <PackageTags>testcontainers docker test tests testing nunit xunit integration database arangodb</PackageTags>
+    <PackageTags>$(PackageTags) database arangodb</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Container.Database.MsSql/Container.Database.MsSql.csproj
+++ b/src/Container.Database.MsSql/Container.Database.MsSql.csproj
@@ -3,25 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TestContainers.Container.Database.MsSql</RootNamespace>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>TestContainers.Container.Database.MsSql</AssemblyName>
-    <Description>DotNet port of testcontainers.org</Description>
-
-    <Version>1.5.4</Version>
-    <Authors>Isen Ng</Authors>
-
-    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
-
-    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <PackageTags>testcontainers docker test tests testing nunit xunit integration database adonet mssql</PackageTags>
+    <PackageTags>$(PackageTags) database adonet mssql</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Container.Database.MySql/Container.Database.MySql.csproj
+++ b/src/Container.Database.MySql/Container.Database.MySql.csproj
@@ -3,25 +3,15 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TestContainers.Container.Database.MySql</RootNamespace>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>TestContainers.Container.Database.MySql</AssemblyName>
-    <Description>DotNet port of testcontainers.org</Description>
+    <PackageTags>$(PackageTags) database adonet mysql mariadb</PackageTags>
+  </PropertyGroup>
 
-    <Version>1.5.4</Version>
-    <Authors>Isen Ng,Sylvain Rollinet</Authors>
-
-    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
-
-    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <PackageTags>testcontainers docker test tests testing nunit xunit integration database adonet mysql mariadb</PackageTags>
+  <PropertyGroup>
+    <Authors>$(Authors),Sylvain Rollinet</Authors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Container.Database.PostgreSql/Container.Database.PostgreSql.csproj
+++ b/src/Container.Database.PostgreSql/Container.Database.PostgreSql.csproj
@@ -3,25 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TestContainers.Container.Database.PostgreSql</RootNamespace>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>TestContainers.Container.Database.PostgreSql</AssemblyName>
-    <Description>DotNet port of testcontainers.org</Description>
-
-    <Version>1.5.4</Version>
-    <Authors>Isen Ng</Authors>
-
-    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
-
-    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <PackageTags>testcontainers docker test tests testing nunit xunit integration database adonet postgresql</PackageTags>
+    <PackageTags>$(PackageTags) database adonet postgresql</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Container.Database/Container.Database.csproj
+++ b/src/Container.Database/Container.Database.csproj
@@ -3,25 +3,11 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>TestContainers.Container.Database</RootNamespace>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>
     <AssemblyName>TestContainers.Container.Database</AssemblyName>
-    <Description>DotNet port of testcontainers.org</Description>
-
-    <Version>1.5.4</Version>
-    <Authors>Isen Ng</Authors>
-
-    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
-
-    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-
-    <PackageTags>testcontainers docker test tests testing nunit xunit integration database</PackageTags>
+    <PackageTags>$(PackageTags) database</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>10</LangVersion>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Description>DotNet port of testcontainers.org</Description>
+
+    <Version>1.5.4</Version>
+    <Authors>Isen Ng</Authors>
+
+    <PackageProjectUrl>https://github.com/isen-ng/testcontainers-dotnet</PackageProjectUrl>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/isen-ng/testcontainers-dotnet/master/LICENSE</PackageLicenseUrl>
+
+    <RepositoryUrl>https://github.com/isen-ng/testcontainers-dotnet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+
+    <PackageTags>testcontainers docker test tests testing nunit xunit integration</PackageTags>
+  </PropertyGroup>
+
+</Project>

--- a/test/Container.Abstractions.Integration.Tests/Container.Abstractions.Integration.Tests.csproj
+++ b/test/Container.Abstractions.Integration.Tests/Container.Abstractions.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Container.Abstractions.Integration.Tests/Container.Abstractions.Integration.Tests.csproj
+++ b/test/Container.Abstractions.Integration.Tests/Container.Abstractions.Integration.Tests.csproj
@@ -2,26 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Abstractions\Container.Abstractions.csproj" />
-    <ProjectReference Include="..\Container.Test.Utility\Container.Test.Utility.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="Images\Fixtures\dockerfiles\**\*">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <None Update="Images\Fixtures\dockerfiles\**\*" CopyToOutputDirectory="Always" />
   </ItemGroup>
 
 </Project>

--- a/test/Container.Abstractions.Tests/Container.Abstractions.Tests.csproj
+++ b/test/Container.Abstractions.Tests/Container.Abstractions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Container.Abstractions.Tests/Container.Abstractions.Tests.csproj
+++ b/test/Container.Abstractions.Tests/Container.Abstractions.Tests.csproj
@@ -2,16 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Moq" Version="4.13.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Abstractions\Container.Abstractions.csproj" />

--- a/test/Container.Database.ArangoDb.Integration.Tests/Container.Database.ArangoDb.Integration.Tests.csproj
+++ b/test/Container.Database.ArangoDb.Integration.Tests/Container.Database.ArangoDb.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Container.Database.ArangoDb.Integration.Tests/Container.Database.ArangoDb.Integration.Tests.csproj
+++ b/test/Container.Database.ArangoDb.Integration.Tests/Container.Database.ArangoDb.Integration.Tests.csproj
@@ -2,25 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Database.ArangoDb\Container.Database.ArangoDb.csproj" />
-    <ProjectReference Include="..\Container.Test.Utility\Container.Test.Utility.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/test/Container.Database.MsSql.Integration.Tests/Container.Database.MsSql.Integration.Tests.csproj
+++ b/test/Container.Database.MsSql.Integration.Tests/Container.Database.MsSql.Integration.Tests.csproj
@@ -2,25 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Database.MsSql\Container.Database.MsSql.csproj" />
-    <ProjectReference Include="..\Container.Test.Utility\Container.Test.Utility.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/test/Container.Database.MsSql.Integration.Tests/Container.Database.MsSql.Integration.Tests.csproj
+++ b/test/Container.Database.MsSql.Integration.Tests/Container.Database.MsSql.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -22,5 +22,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
 </Project>

--- a/test/Container.Database.MySql.Integration.Tests/Container.Database.MySql.Integration.Tests.csproj
+++ b/test/Container.Database.MySql.Integration.Tests/Container.Database.MySql.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/test/Container.Database.MySql.Integration.Tests/Container.Database.MySql.Integration.Tests.csproj
+++ b/test/Container.Database.MySql.Integration.Tests/Container.Database.MySql.Integration.Tests.csproj
@@ -2,26 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
-    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Database.MySql\Container.Database.MySql.csproj" />
-    <ProjectReference Include="..\Container.Test.Utility\Container.Test.Utility.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/test/Container.Database.PostgreSql.Integration.Tests/Container.Database.PostgreSql.Integration.Tests.csproj
+++ b/test/Container.Database.PostgreSql.Integration.Tests/Container.Database.PostgreSql.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -22,5 +22,5 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
-  
+
 </Project>

--- a/test/Container.Database.PostgreSql.Integration.Tests/Container.Database.PostgreSql.Integration.Tests.csproj
+++ b/test/Container.Database.PostgreSql.Integration.Tests/Container.Database.PostgreSql.Integration.Tests.csproj
@@ -2,25 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Database.PostgreSql\Container.Database.PostgreSql.csproj" />
-    <ProjectReference Include="..\Container.Test.Utility\Container.Test.Utility.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Update="xunit.runner.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 
 </Project>

--- a/test/Container.Test.Utility/Container.Test.Utility.csproj
+++ b/test/Container.Test.Utility/Container.Test.Utility.csproj
@@ -6,10 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Docker.DotNet" Version="3.125.5" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Abstractions\Container.Abstractions.csproj" />
   </ItemGroup>
 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(MSBuildProjectName) != 'Container.Test.Utility'">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <ProjectReference Include="$(MSBuildThisFileDirectory)\Container.Test.Utility\Container.Test.Utility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/test/ResourceReaper.Integration.Tests/ResourceReaper.Integration.Tests.csproj
+++ b/test/ResourceReaper.Integration.Tests/ResourceReaper.Integration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/ResourceReaper.Integration.Tests/ResourceReaper.Integration.Tests.csproj
+++ b/test/ResourceReaper.Integration.Tests/ResourceReaper.Integration.Tests.csproj
@@ -2,21 +2,14 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.7.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Container.Abstractions\Container.Abstractions.csproj" />
-    <ProjectReference Include="..\Container.Test.Utility\Container.Test.Utility.csproj" />
   </ItemGroup>
 
 </Project>

--- a/testcontainers-dotnet.sln
+++ b/testcontainers-dotnet.sln
@@ -1,5 +1,8 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1ADD6063-F7A1-4BB6-98CE-A7EC643FD20F}"
+	ProjectSection(SolutionItems) = preProject
+		src\Directory.Build.props = src\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Container.Abstractions", "src\Container.Abstractions\Container.Abstractions.csproj", "{AEB3BDF2-12AC-4446-8F56-0D1EEBF1F2EF}"
 EndProject

--- a/testcontainers-dotnet.sln
+++ b/testcontainers-dotnet.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1ADD6063-F7A1-4BB6-98CE-A7EC643FD20F}"
 	ProjectSection(SolutionItems) = preProject
 		src\Directory.Build.props = src\Directory.Build.props
@@ -7,6 +7,9 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Container.Abstractions", "src\Container.Abstractions\Container.Abstractions.csproj", "{AEB3BDF2-12AC-4446-8F56-0D1EEBF1F2EF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{558B7340-0330-4D4A-87D9-680D83CFD1A1}"
+	ProjectSection(SolutionItems) = preProject
+		test\Directory.Build.props = test\Directory.Build.props
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Container.Abstractions.Tests", "test\Container.Abstractions.Tests\Container.Abstractions.Tests.csproj", "{02299ABE-A972-46D1-A1B0-156ABCB6384F}"
 EndProject


### PR DESCRIPTION
* Use `Directory.Build.props` files to share common properties between projects to ease maintenance
* Update test projects to .NET 6 (.NET Core 2.2 is out of support since since December 23, 2019)